### PR TITLE
Add tests for explicit casting

### DIFF
--- a/src/virtual-funcs/virtual_func_tests.cpp
+++ b/src/virtual-funcs/virtual_func_tests.cpp
@@ -25,7 +25,7 @@ class ParentNoVirt {
     }
     
     void printStatusc() {
-      std::cout << "Take a look! We're running inside the parent class, "
+      std::cout << "        running inside the parent class, "
                 << "unabashedly." << std::endl;
     }
 
@@ -42,7 +42,7 @@ class ChildNoVirt : public ParentNoVirt {
     }
 
     void printStatusc() {
-      std::cout << "Take a look! We're running inside the child class... "
+      std::cout << "        running inside the child class. "
                 << "That's pretty cool." << std::endl;
     }
 
@@ -62,7 +62,7 @@ class ParentVirt {
     }
     
     virtual void printStatusc() {
-      std::cout << "Take a look! We're running inside the parent class, "
+      std::cout << "        Take a look! We're running inside the parent class, "
                 << "despite being marked as virtual. I bet you didn't "
                 << "instantiate it using a child class this time, did you!"
                 << std::endl;
@@ -80,26 +80,58 @@ class ChildVirt : public ParentVirt {
     }
     
     virtual void printStatusc() {
-      std::cout << "Take a look! We're running inside the child class, "
+      std::cout << "        Take a look! We're running inside the child class, "
                 << "because the function was marked as virtual." << std::endl;
     }
 };
 
 int main() {
-  std::cout << "Trying with type (ParentNoVirt *)..." << std::endl;
+  std::cout << "=== Let's omit the `virtual` keyword ===" << std::endl
+            << std::endl;
+  
+  std::cout << "Trying with type (ParentNoVirt *) with Constructor ChildNoVirt()"
+            << "..." << std::endl;
   ParentNoVirt *testNoVirt = new ChildNoVirt();
+  std::cout << "    CAST to a (ChildNoVirt *):" << std::endl;
+  ((ChildNoVirt *)testNoVirt)->printStatusc();
+  std::cout << "    NO CAST to a (ChildNoVirt *):" << std::endl;
   testNoVirt->printStatusc();
-
+  
+  std::cout << "Trying with type (ChildNoVirt *) with Constructor ChildNoVirt()"
+            << "..." << std::endl;
+  ChildNoVirt *testChildNoVirt = new ChildNoVirt();
+  std::cout << "    CAST to a (ParentNoVirt *):" << std::endl;
+  ((ParentNoVirt*) testChildNoVirt)->printStatusc();
+  std::cout << "    NO CAST to a (ParentNoVirt *):" << std::endl;
+  testChildNoVirt->printStatusc();
   std::cout << std::endl;
-  std::cout << "Trying with type (ParentVirt *)..." << std::endl;
+  std::cout << "=== Now let's apply the `virtual` keyword ===" << std::endl
+            << std::endl;
+  
+  std::cout << "Trying with type (ParentVirt *) with Constructor ChildVirt()..."
+            << std::endl;
   ParentVirt *testWithVirt = new ChildVirt();
+  std::cout << "    Get this -- whether we CAST to a (ChildVirt *) or not,"
+            << "the child class\' printStatus is called:" << std::endl;
   testWithVirt->printStatusc();
-
+  ((ChildVirt*) testWithVirt)->printStatusc();
+  
+  std::cout << "Trying with type (ChildVirt *) with Constructor ChildVirt()..."
+            << "..." << std::endl;
+  ChildVirt *trueChildWithVirt = new ChildVirt();
+  std::cout << "    Get this -- whether we CAST to a (ParentVirt *) or not,"
+            << "the child class\' printStatus is called:" << std::endl;
+  trueChildWithVirt->printStatusc();
+  ((ParentVirt*) trueChildWithVirt)->printStatusc();
+  
   std::cout << std::endl;
   delete testNoVirt;
+  delete testChildNoVirt;
   delete testWithVirt;
+  delete trueChildWithVirt;
 
-  /* Now I want to test using smart pointers to check if it's any different */
+  /* Now I want to test using smart pointers to check if it's any different
+   * (edit: they are not). */
 
   std::cout << std::endl;
   std::cout << "Trying with type (std::unique_ptr<ParentNoVirt>)..." << std::endl;

--- a/src/virtual-funcs/virtual_func_tests.cpp
+++ b/src/virtual-funcs/virtual_func_tests.cpp
@@ -1,6 +1,6 @@
 /*
  *
- * This is a long-overdue set of tests to make sure that I really unerstand,
+ * This is a long-overdue set of tests to make sure that I really understand,
  * at a deep level, the use of the keyword `virtual`.
  *
  * I was always trained to use `virtual` whenever a subclass has an overridden


### PR DESCRIPTION
These updates will drive the point home on the importance of using `virtual`. This hadn't been clear until we actually tried casting to different pointer types. If I recall correctly, this update was inspired by a video from "whatsacreel" on YouTube.